### PR TITLE
Fix: imcompatibilites in dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 scipy
-astropy
+astropy==5.3
 photutils==1.1.0
 matplotlib
 reproject >= 0.7


### PR DESCRIPTION
In the main branch now, under Python3.9, there are conflict in requirements:

- Astropy==6.0: This version triggered an ImportError due to the deprecated update_default_config. The issue may be linked to the specified photutils==1.1.0 in the requirements, while the latest version is 1.10.0
- Astropy==6.0 functions well when combined with photutils==1.10.0 in my code.
- Astropy 5.0: This version led to an AttributeError, specifically "module 'numpy' has no attribute 'asscalar'."
- Astropy 5.3, 5.2, 5.1: These versions works with current requirements.txt file.

This PR fix imports errors by assigning astropy==5.3 in requirements.txt

> Note: this is a temporary fix
A further test is on the way.